### PR TITLE
Replace 'rockerouter' with 'rocker-outerer'

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
   <!-- 05 Oct 2012 -->
   <meta name="author"  content="orta; http://orta.github.com/" /> 
   <meta name="title" content="orta therox" /> 
-  <meta name="description" content="programmer and general rockerouterer." /> 
+  <meta name="description" content="programmer and general rocker-outerer." /> 
   <meta name="keywords" content="orta, ios, ortatherox, design, designer, code, iphone, awesome, iphone games, iphone apps, cocoa, cocoa apps, therox, cocos2d, flash, as3, html, css, github" /> 
   <meta name="robots" content="all,follow"/> 
   <link rel="alternate" type="application/atom+xml" title="Atom Blog Feed" href="/blog.atom" />


### PR DESCRIPTION
When you posted the link on FB to your annual writeup (<3), your description text read "programmer and general rockerouter". My first thought was, "what's a rocke, and why does Orta router them?"

This makes it a bit more unambiguous :)