### PR TITLE
Fix typos across orta.github.com repo

### DIFF
--- a/_posts/2011-01-04-games.html
+++ b/_posts/2011-01-04-games.html
@@ -170,7 +170,7 @@ frontpage : true
    <article> 
       <a href = "http://www.youtube.com/v/jrzhlTn1_ds&hl=en&fs=1&rel=0&autoplay=1" rel="shadowbox;width=405;height=340;player=swf"><img src="/old/images/games/osmos.jpg" alt="Osmos"/></a> 
 
-     <p>Relaxing. In Osmos you are a single celled organism you have to absorb smaller organisms into yourself. It's very similar in concept to the inital part of the game Spore, but more indie. Presentationally Presentation-wise it feels like you're looking down a microscope at some nuclear cells bumping into each other. </p> 
+     <p>Relaxing. In Osmos you are a single celled organism you have to absorb smaller organisms into yourself. It's very similar in concept to the initial part of the game Spore, but more indie. Presentationally Presentation-wise it feels like you're looking down a microscope at some nuclear cells bumping into each other. </p> 
 
        <p>There are three main types of game; become the biggest, get the something, survive what's going on. Become the biggest is a nice simple game where you go around absorbing what is smaller. Getting the something can prove to be a bit of a challenge as the something could also be competing for smaller organisms to grow with. The "Survive what's going on" levels are usually trying to control yourself in what is essentially wind. You need planning on those levels, but it's a nice game, throw in the beautiful bubbly soundtrack and you can sit down and distract yourself for a while.</p> 
    </article> 

--- a/_posts/2012-11-08-26.markdown
+++ b/_posts/2012-11-08-26.markdown
@@ -12,7 +12,7 @@ be summed up up quite easily as being travel and code.
 {% include full_image.html image="https://ortastuff.s3.amazonaws.com/2013/images/26/nyc.jpg" tag_header="America" tag_body="New York City" %}
 
 I had wanted to get out to NYC sooner, my job at Artsy still hadn't fully started as at Art.sy everyone gets a 3 month
-intro period before being offered full employment. This process keeps it democratic and everyone invovled gets a say in
+intro period before being offered full employment. This process keeps it democratic and everyone involved gets a say in
 whether someone works with us. I wanted to meet all these screen names for the dev chat. I’d also made a promise to
 Kierononon^on that I’d do a gig in November. I’d been trying to put off making any plans longer than a month or two away
 because I couldn’t be too sure of when I was heading out.
@@ -145,7 +145,7 @@ As if that wasn’t enough, I made weekend plans to try see some works by my fav
 to see the works which kinda sucks. I think grax enjoyed it though.
 
 My older sister had a kid in June, with a cool mathematical name of Delta. I’ve yet to meet her though. Except on skype.
-The other had a kid in Febuary 2013.
+The other had a kid in February 2013.
 
 These few months were kinda slow for events, I spent a lot of my free time exercising and working on Put.IO. I did some
 lazer quest, I had a hilarious poker night go wrong when I won the pot and paid for everyone’s drinks. My cousins

--- a/_posts/2014-11-21-28.markdown
+++ b/_posts/2014-11-21-28.markdown
@@ -89,7 +89,7 @@ Tap talk is another ephemeral photos app. It's aimed towards taking a picture (o
 
 {% include full_image.html image="https://ortastuff.s3.amazonaws.com/images/28/taptalk.jpg" tag_header="TAPTALK" tag_body="The World" url="http://orta.io/taptalk" %}
 
-I really, really enjoyed UIKonf. I felt like it was exactly the sort of conference I would like to run myself. Also rather convienently  Afterwards I went back to England to spend some quality time with Danger before setting off to San Francisco, it was WWDC in time for June.
+I really, really enjoyed UIKonf. I felt like it was exactly the sort of conference I would like to run myself. Also rather conveniently  Afterwards I went back to England to spend some quality time with Danger before setting off to San Francisco, it was WWDC in time for June.
 
 WWDC is this big thing. It's a monolithic conference ran by Apple that for many years was the only Mac + iOS conference, and is pretty much the only thing at it's scale for our community. It brings thousands of developers to San Francisco for a few weeks and is a great time to meet a bunch of people that you've only seen an avatar for. I went early, the lovely Delisa Mason let me crash at her place and we went to the Ruby Motion [motion#inspect][56] conference to say hi to [Alloy][57] and the Motion team. They announced Motion on Android, I think that's super awesome. It was fun to hang out. Delisa and I played some video games. The rest of the Artsy mobile team came out ( they had WWDC tickets ) to SF later too! It was fun, it was the first time we had the entire mobile Artsy team in a single place.
 

--- a/_posts/2016-12-19-30.markdown
+++ b/_posts/2016-12-19-30.markdown
@@ -111,7 +111,7 @@ the project to keep up to date or do anything new.
 This year I joined the JavaScript community.
 
 One of my favourite differences between the JavaScript community and the iOS community is the feeling of being able to
-build and fix your own problems. You can work on an entirely open stack, use open tools and can help out whereever you
+build and fix your own problems. You can work on an entirely open stack, use open tools and can help out wherever you
 want..
 
 JavaScript is basically the primordial soup of programming, which was fascinating to watch - and as a contributor, this
@@ -139,7 +139,7 @@ to overstate the change that this is. I wanted to be a Mac developer since I sta
 Objective-C and native apps for a decade and this year that changed.
 
 The reason for this is a general discomfort with the current status-quo around building apps. It does not feel like it's
-in Apple's interests to change either. Long explaination for that is here:
+in Apple's interests to change either. Long explanation for that is here:
 
 <iframe src="https://player.vimeo.com/video/190737663" width="100%" height="420" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
@@ -175,7 +175,7 @@ room - it feels [really dystopian](http://i.imgur.com/odweUkw.jpg). When I demo 
 impressed on the shorter term.
 
 As we have a full VR setup at home, I get asked about what Porn is like on it. Porn isn't really a thing on VR, it's
-pretty bad. They tend to be 360 videos, which I can only image are relaly awkward to film. The most interesting aspect
+pretty bad. They tend to be 360 videos, which I can only image are really awkward to film. The most interesting aspect
 to me is that [PornHub is producing their own][pornhub] content. It's a bit like when Netflix started making their own
 series. Could bring a lot of changes to the industry.
 

--- a/_posts/2017-12-19-31.markdown
+++ b/_posts/2017-12-19-31.markdown
@@ -61,7 +61,7 @@ had full-control, low expectations and could basically do whatever felt right. W
 living in Huddersfield for over a decade, and I had appointed it as my unofficial-hometown ([Halifax][18] was closer to
 the village where I grew up) - as we were going to move to NYC, we were also considering it a farewell party also.
 
-With both of us being non-religious, (we both subscribe to Optimisitic Nihilism) we could skip on churches and more
+With both of us being non-religious, (we both subscribe to Optimistic Nihilism) we could skip on churches and more
 formal wedding events.
 
 <iframe width="100%" height="500" src="https://www.youtube-nocookie.com/embed/MBRqu0YOH14" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
@@ -105,7 +105,7 @@ We started out in Tokyo for the [try! Swift Tokyo](https://www.tryswift.co), whe
 community.
 
 We spent a lot of time just walking around the tokyo, I'd seen many aspects of the city via anime/games, but it was
-super cool to see what they were actaully representing. We walked through some of the seediest areas, and visited the
+super cool to see what they were actually representing. We walked through some of the seediest areas, and visited the
 terri-great sex shops. I spent days looking for the famous Japanese photo booths, and we got amazing shots.
 
 {% include full_image.html image="https://ortastuff.s3.amazonaws.com/site/on_being/31/japan-photo-booth.jpg" %}

--- a/iphone.textile
+++ b/iphone.textile
@@ -225,7 +225,7 @@ So, sometimes people want to diverge into games. This is cool, so its always a g
 
 "!/assets/images/iphone/sedgwickpong.jpg(Pong Game)!":/assets/files/iphone/SedgwickPong.zip
 
-This is the first app that uses _#define_ to let us create readble code when dealing with numbers. It also is the first to have a seperate run loop ( in this case it is below, running the ball movement and collision detection. )
+This is the first app that uses _#define_ to let us create readble code when dealing with numbers. It also is the first to have a separate run loop ( in this case it is below, running the ball movement and collision detection. )
 
 h4(code_heading). PongLayer.h - header file
 
@@ -269,9 +269,9 @@ h1. Project 8
 
 h2. ILikeSpring
 
-This app is about dealing with persistance, so saving data and loading it. This app keeps track of how many times you've agreed with the fact that Spring Rools.
+This app is about dealing with persistence, so saving data and loading it. This app keeps track of how many times you've agreed with the fact that Spring Rools.
 
-"!/assets/images/iphone/spring.jpg(Persistance App)!":/assets/files/iphone/ILikeSpring.zip
+"!/assets/images/iphone/spring.jpg(Persistence App)!":/assets/files/iphone/ILikeSpring.zip
 
 This application deals with NSUserDefaults, which are a great way to store small amounts of data, and it should be stored across devices with iCloud.
 
@@ -372,7 +372,7 @@ h1. Project 11
 
 h2. PingPong
 
-This is a peer-to-peer chat client that allows you to send text messages between 2 iOS devices, it comes with its own seperate networking class which is generified and can be used in any project and it uses GameKit as the framework for sending data.
+This is a peer-to-peer chat client that allows you to send text messages between 2 iOS devices, it comes with its own separate networking class which is generified and can be used in any project and it uses GameKit as the framework for sending data.
 
 "!/assets/images/iphone/pingpong.jpg(Chat App)!":/assets/files/iphone/PingPong.zip
 


### PR DESCRIPTION
:writing_hand: **Fix typos across orta.github.com repo**

**Files that have typos**

```
orta.github.com/_posts/2011-01-04-games.html:173:148: "inital" is a misspelling of "initial"
orta.github.com/_posts/2012-11-08-26.markdown:15:97: "invovled" is a misspelling of "involved"
orta.github.com/_posts/2012-11-08-26.markdown:148:23: "Febuary" is a misspelling of "February"
orta.github.com/_posts/2014-11-21-28.markdown:92:123: "convienently" is a misspelling of "conveniently"
orta.github.com/_posts/2016-12-19-30.markdown:114:105: "whereever" is a misspelling of "wherever"
orta.github.com/_posts/2016-12-19-30.markdown:142:44: "explaination" is a misspelling of "explanation"
orta.github.com/_posts/2016-12-19-30.markdown:178:67: "relaly" is a misspelling of "really"
orta.github.com/_posts/2017-12-19-31.markdown:64:59: "Optimisitic" is a misspelling of "Optimistic"
orta.github.com/_posts/2017-12-19-31.markdown:108:33: "actaully" is a misspelling of "actually"
orta.github.com/iphone.textile:228:130: "seperate" is a misspelling of "separate"
orta.github.com/iphone.textile:272:31: "persistance" is a misspelling of "persistence"
orta.github.com/iphone.textile:274:35: "Persistance" is a misspelling of "Persistence"
orta.github.com/iphone.textile:375:118: "seperate" is a misspelling of "separate"
```

**PS:** I use [**client9/misspell**](https://github.com/client9/misspell) to scan typos :heart: 

Making the world a better place :innocent: